### PR TITLE
Improve parser structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,29 @@
-# 💡 Avito
+# Avito Parser
 
-Платформа для поиска и анализа актуальных бизнес-идей с использованием нейросетей и данных с популярных ресурсов.
+This project provides simple utilities for parsing apartment listings on [Avito](https://www.avito.ru) and exporting the collected information to Excel.
 
-## 🚀 Возможности
-
-- 🔍 Парсинг свежих идей с VC.ru, Хабра, РБК Трендов и других источников
-- 🧠 Генерация идей на основе GPT
-- 🏷 Автоматическая категоризация: IT, AI, Эко, FoodTech и др.
-- 👤 Профили пользователей, выбор идеи, история действий
-- 💬 Telegram-бот с советами по адаптации идеи под твой бизнес
-- 🦾 Интерактивный маскот на главной странице с подсказками
-- 📊 Админ-панель с редактированием базы и просмотром ER-диаграммы
-
-## 🛠️ Технологии
-
-- **Frontend:** React + TypeScript + TailwindCSS + Framer Motion
-- **Backend / DB:** Supabase (PostgreSQL + Auth)
-- **AI:** OpenAI GPT API
-- **3D:** Spline
-- **Интеграция:** Telegram Bot API
-
-## 📦 Установка
+## Setup
 
 ```bash
-git clone https://github.com/Iam3tonn/BizIdeasProject.git
-cd BizIdeasProject
-npm install
-npm run dev
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
 ```
 
-## 🧠 Архитектура
+## Usage
 
-- `src/pages/`: Главные страницы (Home, Ideas, Profile и т.д.)
-- `src/contexts/`: Авторизация и глобальные состояния
-- `supabase/`: Взаимодействие с базой
-- `public/`: Логотипы, маскот и т.д.
+Run the interactive parser:
 
-## ⚙️ Деплой
-
-Проект можно легко задеплоить на [Railway](https://railway.app):
-
-1. Подключи GitHub репозиторий
-2. Railway сам установит зависимости и запустит `vite preview`
-3. Укажи в `package.json`:
-
-```json
-"scripts": {
-  "dev": "vite",
-  "build": "vite build",
-  "start": "vite preview"
-}
+```bash
+python main.py
 ```
 
-## 📬 Связь
+You will be prompted for an Avito advertisement URL. Parsed data will be saved to `output/apartments.xlsx`.
 
-Если хочешь внести вклад, задать вопрос или предложить идею:
-- Telegram: [@i6_dEv_9i](https://t.me/i6_dEv_9i)
-- Email: dimathedevoloper@gmail.com
+## Testing
 
----
+Tests are located in the `tests/` directory and can be executed with:
 
-**BizIdeasProject — идеи, которые двигают бизнес.**
+```bash
+python -m pytest -q
+```

--- a/config.py
+++ b/config.py
@@ -1,0 +1,19 @@
+"""Project configuration values."""
+
+# Cookie string for authenticated Avito requests. Replace with your own if needed.
+AVITO_COOKIE: str = ""
+
+# Default HTTP headers used for Avito requests
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/115.0.0.0 Safari/537.36"
+    ),
+    "Referer": "https://www.avito.ru/",
+    "Cookie": AVITO_COOKIE,
+}
+
+# Output paths
+OUTPUT_FILE = "output/apartments.xlsx"
+PRICE_CHART_FILE = "output/price_chart.png"

--- a/main.py
+++ b/main.py
@@ -1,60 +1,24 @@
+"""Command line interface for parsing a single Avito advertisement."""
+
+from __future__ import annotations
+
 import pandas as pd
-from parsers.avito import parse_avito, get_districts
+
+from parsers.avito import parse_avito
 from utils.excel_manager import save_to_excel
 
-def get_user_input():
-    # Ввод города
-    city = input("🔍 Введите ваш город: ").strip()
 
-    # Парсим районы
-    print("\n📍 Загружаем районы...")
-    districts = get_districts(city)
-    
-    if not districts:
-        print("❌ Не удалось найти районы. Проверьте название города.")
-        return city, None
-
-    print("\n📌 Доступные районы:")
-    for idx, district in enumerate(districts, 1):
-        print(f"{idx}. {district}")
-
-    # Выбор района
-    while True:
-        try:
-            choice = int(input("\nВведите номер района: "))
-            if 1 <= choice <= len(districts):
-                selected_district = districts[choice - 1]
-                break
-            else:
-                print("❌ Неверный номер. Выберите из списка.")
-        except ValueError:
-            print("❌ Введите цифру.")
-
-    return city, selected_district
-
-def main():
-    city, district = get_user_input()
-
-    if not district:
-        print("❌ Парсинг отменен.")
+def main() -> None:
+    url = input("🔗 Введите ссылку на объявление Avito: ").strip()
+    data = parse_avito(url)
+    if not data:
+        print("❌ Не удалось получить данные.")
         return
 
-    print(f"\n🔎 Ищем квартиры в {city}, район: {district}...\n")
+    df = pd.DataFrame([data])
+    output_file = save_to_excel(df)
+    print(f"✅ Данные сохранены в {output_file}")
 
-    # Парсим данные
-    avito_data = parse_avito(city, district)
-
-    if not avito_data:
-        print("❌ Данные не найдены.")
-        return
-
-    # Конвертируем в DataFrame
-    df = pd.DataFrame(avito_data)
-
-    # Сохраняем в Excel
-    save_to_excel(df)
-
-    print("✅ Данные сохранены в Excel!")
 
 if __name__ == "__main__":
     main()

--- a/parsers/cian.py
+++ b/parsers/cian.py
@@ -1,0 +1,10 @@
+"""Stub parser for CIAN service."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def parse_cian(url: str) -> Dict[str, Any]:
+    """Parse a CIAN advertisement page (not implemented)."""
+    raise NotImplementedError("CIAN parser is not implemented")

--- a/parsers/domclick.py
+++ b/parsers/domclick.py
@@ -1,0 +1,10 @@
+"""Stub parser for DomClick service."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def parse_domclick(url: str) -> Dict[str, Any]:
+    """Parse a DomClick advertisement page (not implemented)."""
+    raise NotImplementedError("DomClick parser is not implemented")

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,17 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils.filters import filter_by_price
+
+
+def test_filter_by_price():
+    data = [
+        {"Цена": "1000"},
+        {"Цена": "2000"},
+        {"Цена": "3000"},
+    ]
+    result = filter_by_price(data, 1500, 2500)
+    assert len(result) == 1
+    assert result[0]["Цена"] == "2000"

--- a/utils/excel_manager.py
+++ b/utils/excel_manager.py
@@ -1,15 +1,38 @@
-import openpyxl
-from openpyxl.drawing.image import Image
-import requests
+"""Helpers for exporting parsed data to Excel."""
+
+from __future__ import annotations
+
 from io import BytesIO
+from pathlib import Path
+from typing import Any
+
 import matplotlib.pyplot as plt
+import openpyxl
 import pandas as pd
+import requests
+from openpyxl.drawing.image import Image
 
-OUTPUT_FILE = "output/apartments.xlsx"
+import config
 
-def save_to_excel(df):
-    print("📂 Сохраняем данные в Excel...")
-    
+
+def save_to_excel(df: pd.DataFrame, output: Path | None = None) -> Path:
+    """Save the provided DataFrame to an Excel file with basic charts.
+
+    Parameters
+    ----------
+    df: pandas.DataFrame
+        Parsed apartments information.
+    output: pathlib.Path | None
+        Destination file path. Uses ``config.OUTPUT_FILE`` by default.
+
+    Returns
+    -------
+    pathlib.Path
+        Path to the saved file.
+    """
+    destination = Path(output or config.OUTPUT_FILE)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
     wb = openpyxl.Workbook()
     ws = wb.active
     ws.title = "Квартиры"
@@ -18,22 +41,25 @@ def save_to_excel(df):
 
     for i, row in df.iterrows():
         ws.append(row.tolist())
-
         for j in range(3):
-            photo_url = row[f"Фото {j+1}"]
-            if photo_url:
-                try:
-                    img_data = requests.get(photo_url).content
-                    img = Image(BytesIO(img_data))
-                    img.width, img.height = 100, 75
-                    ws.add_image(img, f"H{i+2}")
-                except:
-                    pass
+            photo_url = row.get(f"Фото {j+1}")
+            if not photo_url:
+                continue
+            try:
+                img_data = requests.get(photo_url, timeout=10).content
+                img = Image(BytesIO(img_data))
+                img.width, img.height = 100, 75
+                ws.add_image(img, f"H{i+2}")
+            except requests.RequestException:
+                pass
 
     ws_chart = wb.create_sheet("Графики")
 
     df["Цена"] = df["Цена"].astype(int)
     df_grouped = df.groupby("Район")["Цена"].mean().sort_values()
+
+    chart_path = Path(config.PRICE_CHART_FILE)
+    chart_path.parent.mkdir(parents=True, exist_ok=True)
 
     plt.figure(figsize=(10, 5))
     df_grouped.plot(kind="bar", color="skyblue")
@@ -41,10 +67,9 @@ def save_to_excel(df):
     plt.ylabel("Цена, ₽")
     plt.xticks(rotation=45, ha="right")
     plt.tight_layout()
-    plt.savefig("output/price_chart.png")
+    plt.savefig(chart_path)
 
-    img_chart = Image("output/price_chart.png")
-    ws_chart.add_image(img_chart, "A1")
+    ws_chart.add_image(Image(str(chart_path)), "A1")
 
-    wb.save(OUTPUT_FILE)
-    print(f"✅ Файл сохранен: {OUTPUT_FILE}")
+    wb.save(destination)
+    return destination

--- a/utils/filters.py
+++ b/utils/filters.py
@@ -1,0 +1,19 @@
+"""Utility functions for filtering parsed data."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def filter_by_price(items: List[Dict[str, Any]], min_price: int, max_price: int) -> List[Dict[str, Any]]:
+    """Return advertisements with ``Цена`` between ``min_price`` and ``max_price``."""
+    result: List[Dict[str, Any]] = []
+    for item in items:
+        price_text = str(item.get("Цена", "0")).split()[0]
+        try:
+            price = int(price_text)
+        except ValueError:
+            continue
+        if min_price <= price <= max_price:
+            result.append(item)
+    return result

--- a/utils/image_downloader.py
+++ b/utils/image_downloader.py
@@ -1,0 +1,22 @@
+"""Simple helper for downloading images."""
+
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+
+def download_image(url: str, dest: Path, *, timeout: int = 10) -> Optional[Path]:
+    """Download an image from ``url`` and save it to ``dest``.
+
+    Returns the destination path on success or ``None`` on error.
+    """
+    try:
+        response = requests.get(url, timeout=timeout)
+        response.raise_for_status()
+    except requests.RequestException:
+        return None
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(response.content)
+    return dest


### PR DESCRIPTION
## Summary
- document Python usage in `README.md`
- add configuration with headers and output paths
- simplify CLI to parse a single Avito ad
- refactor Avito parser for safer headers and error handling
- flesh out empty modules with minimal implementations
- add helper tests for filters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422405f6088323a26c29c8578434ee